### PR TITLE
Hot maps/code update

### DIFF
--- a/find_hotspot_regions_gene.py
+++ b/find_hotspot_regions_gene.py
@@ -242,6 +242,11 @@ def main(opts):
                                for m in mtc_ttype])
 
         # read annotation file
+        # get full ttype string from directory
+        for ann_file in os.listdir(opts['annotation_dir']):
+            prefix = 'mupit_mutations_' + ttype
+            if ann_file.startswith(prefix):
+                ttype = ann_file.split('mupit_mutations_')[-1]
         annotation_file = os.path.join(opts['annotation_dir'], 'mupit_mutations_' + ttype)
         annotation, col_pos = read_mupit_file(annotation_file, significant_res)
         pdb_ix = col_pos['pdb']
@@ -282,7 +287,7 @@ def main(opts):
                 try:
                    tmp_pos =  (s[col_pos['chain']], int(s[col_pos['pdb_res']]))
                 except:
-                    print 'int error'
+                    print(f'int error:\n{s}')
                     continue
                 signif_struct_info[tmp_pos] = (s[anot_gene_ix], s[anot_tx_ix], s[anot_res_ix])
 
@@ -303,7 +308,7 @@ def main(opts):
     output += tmp_out
 
     # write output
-    with open(opts['output'], 'wb') as handle:
+    with open(opts['output'], 'w') as handle:
         for line in output:
             handle.write('\t'.join(line)+'\n')
 

--- a/find_hotspot_regions_struct.py
+++ b/find_hotspot_regions_struct.py
@@ -251,7 +251,7 @@ def update_graph(struct2graph, all_cogs, signif_struct_info, non_signif_struct_i
             except KeyError:
                 # skip deleted chains, or models without a chain
                 # be careful this catches all keyerrors
-                print cur_pdb
+                print(cur_pdb)
                 pass
 
     return struct2graph, signif_res_neighbors
@@ -354,6 +354,11 @@ def main(opts):
                            for m in mtc_ttype]
 
         # read annotation file
+        # get full ttype string from directory
+        for ann_file in os.listdir(opts['annotation_dir']):
+            prefix = 'mupit_mutations_' + ttype
+            if ann_file.startswith(prefix):
+                ttype = ann_file.split('mupit_mutations_')[-1]
         annotation_file = os.path.join(opts['annotation_dir'],
                                        'mupit_mutations_' + ttype)
         all_annotation, col_pos = read_mupit_file(annotation_file, significant_res)
@@ -423,7 +428,7 @@ def main(opts):
 
 
     # write output
-    with open(opts['output'], 'wb') as handle:
+    with open(opts['output'], 'w') as handle:
         for line in output:
             handle.write('\t'.join(line)+'\n')
 

--- a/hotspot.py
+++ b/hotspot.py
@@ -144,6 +144,8 @@ def main(opts):
                      for t in unique_ttypes}
         unique_ttypes = list(unique_ttypes)
 
+        # Print current structure
+        print(f"Obtaining tmp info for {structure_id}...")
         # obtain relevant info from structure
         tmp_info = get_structure_info(structure, mchains, mres, mcount,
                                       struct_chains, ttype_ixs)

--- a/multiple_testing_correction.py
+++ b/multiple_testing_correction.py
@@ -260,7 +260,9 @@ def main(opts):
         myfunc = max
     for m_file in os.listdir(mupit_dir):
         # print the tumor type we're on
-        ttype = m_file.split('_')[-1]
+        #ttype = m_file.split('_')[-1]
+        ttype = m_file.split('mupit_mutations_')[-1]
+        ttype = ttype[:10]
         # skip cancer type if no mutations/hotspots.
         # usually only happens if they use only a couple structures
         # and not the full PDB
@@ -298,12 +300,12 @@ def main(opts):
             signif_lvl_output.append([ttype, pval_cutoff])
 
     # write to output file
-    with open(out_file, 'wb') as out_file:
+    with open(out_file, 'w') as out_file:
         mywriter = csv.writer(out_file, delimiter='\t', lineterminator='\n')
         mywriter.writerows([header]+output)
 
     # write significance level cutoffs for each tumor type
-    with open(signif_lvl_file, 'wb') as out_file:
+    with open(signif_lvl_file, 'w') as out_file:
         mywriter = csv.writer(out_file, delimiter='\t', lineterminator='\n')
         mywriter.writerows(signif_lvl_output)
     #print("MISSING COUNTS = " + str(MISSING_COUNT))

--- a/scripts/add_path_info.py
+++ b/scripts/add_path_info.py
@@ -15,8 +15,8 @@ import logging
 logger = logging.getLogger(__name__)  # module logger
 
 # directories for various pdb files
-import ConfigParser
-config = ConfigParser.SafeConfigParser()
+import configparser
+config = configparser.ConfigParser()
 config.read(os.path.join(file_dir, '../config.txt'))
 refseq_dir = config.get('PDB', 'refseq_homology')
 ensembl_dir = config.get('PDB', 'ensembl_homology')
@@ -91,9 +91,19 @@ def main(opts):
             if struct_id.startswith('ENSP'):
                 # pdb_path = os.path.abspath(os.path.join(ensemble_dir, '{0}.pdb'.format(struct_id[4:].lstrip('0'))))
                 pdb_path = os.path.abspath(os.path.join(ensembl_dir, '{0}.pdb'.format(struct_id)))
+                if not os.path.exists(pdb_path):
+                    if os.path.exists(pdb_path + ".gz"):
+                        pdb_path = pdb_path + ".gz"
             elif struct_id.startswith('NP'):
                 pdb_path = os.path.abspath(os.path.join(refseq_dir, '{0}.pdb'.format(struct_id)))
+                if not os.path.exists(pdb_path):
+                    if os.path.exists(pdb_path + ".gz"):
+                        pdb_path = pdb_path + ".gz"
             else:
+                # Find non-biological assembly files in divided PDB directories
+                subdir = struct_id[1:3]
+                putative_divided_path1 = os.path.join(pdb_dir, subdir, 'pdb{0}.ent.gz'.format(struct_id))
+                putative_divided_path2 = os.path.join(pdb_dir, subdir, 'pdb{0}.pdb.gz'.format(struct_id))
                 # try to get non-biological assembly pdb file path
                 putative_path = os.path.join(pdb_dir, 'pdb{0}.ent.gz'.format(struct_id))
                 # the second path may occur if user downloads PDB from RCSB
@@ -102,6 +112,10 @@ def main(opts):
                     non_biounit_path = putative_path
                 elif os.path.exists(putative_path2):
                     non_biounit_path = putative_path2
+                elif os.path.exists(putative_divided_path1):
+                    non_biounit_path = putative_divided_path1
+                elif os.path.exists(putative_divided_path2):
+                    non_biounit_path = putative_divided_path2
                 else:
                     missing_non_bio_files.append(putative_path)
                 if bio_num_flag:

--- a/scripts/chain_description.py
+++ b/scripts/chain_description.py
@@ -59,7 +59,7 @@ def main(opts):
                     pdb_id = line[header2ix['PDBId']]
                     if non_bio_pdb_path.endswith('.gz'):
                         # handle compressed case
-                        with gzip.open(non_bio_pdb_path, 'rb') as gzhandle:
+                        with gzip.open(non_bio_pdb_path, 'rt') as gzhandle:
                             pdb_header = parse_pdb_header(gzhandle)
                     else:
                         # normal .ent file

--- a/scripts/divide_pdb_info.py
+++ b/scripts/divide_pdb_info.py
@@ -91,7 +91,7 @@ def split_file(in_file, num_splits, split_dir, mut_file):
     mut_dict = read_file(m)
 
     # determine total num of ids in file
-    total_ids = len(pdb_dict.keys())
+    total_ids = len(list(pdb_dict.keys()))
     print(total_ids)
     # determine num of ids to put in each split
     num_ids = int(total_ids/num_splits)
@@ -101,7 +101,7 @@ def split_file(in_file, num_splits, split_dir, mut_file):
     count_id = num_ids
 
     # randomize order of insertions
-    keys = pdb_dict.keys()
+    keys = list(pdb_dict.keys())
     random.shuffle(keys)
 
     # iterate through dict and write to files

--- a/scripts/maf/convert_maf_to_mupit.py
+++ b/scripts/maf/convert_maf_to_mupit.py
@@ -48,6 +48,8 @@ def parse_arguments():
 
 def fix_samp_id(mystring):
     """Remove all of the extra ID info from TCGA barcodes."""
+    if isinstance(mystring,int) or isinstance(mystring,float):
+        mystring = str(mystring)
     if mystring.startswith('TCGA'):
         return mystring[:12]
     else:
@@ -221,7 +223,7 @@ def main(opts):
                         counted_bio = True
 
                 # write line
-                line_str = '\t'.join([pdbid, chain, seqres, genomic_pos] + map(str, row[out_cols].tolist())) + '\n'
+                line_str = '\t'.join([pdbid, chain, seqres, str(genomic_pos)] + list(str(x) for x in row[out_cols].tolist())) + '\n'
                 wf.write(line_str)
 
             count += 1

--- a/scripts/mupit/count_mutations.py
+++ b/scripts/mupit/count_mutations.py
@@ -39,42 +39,40 @@ def main(opts):
                     continue
 
                 # Num sample in each tissue
-                if no_sample.has_key(pdb) == False:
+                if not pdb in no_sample:
                     no_sample[pdb] = {}
                 no_sample[pdb][sample] = True
 
                 # Num sample in all tissues
-                if no_sample_alltissues.has_key(pdb) == False:
+                if not pdb in no_sample_alltissues:
                     no_sample_alltissues[pdb] = {}
                 no_sample_alltissues[pdb][sample] = True
 
-                if seqres_by_pdb.has_key(pdb) == False:
+                if not pdb in seqres_by_pdb:
                     seqres_by_pdb[pdb] = {}
                 seqres_chain = seqres + ':' + chain
                 # Increases tissue specific occurrence.
-                if seqres_by_pdb[pdb].has_key(seqres_chain) == False:
+                if not seqres_chain in seqres_by_pdb[pdb]:
                     seqres_by_pdb[pdb][seqres_chain] = 0
                 seqres_by_pdb[pdb][seqres + ':' + chain] += 1
                 # Increases all-tissue occurrence.
-                if seqres_by_pdb_alltissues.has_key(pdb) == False:
+                if not pdb in seqres_by_pdb_alltissues:
                     seqres_by_pdb_alltissues[pdb] = {}
-                if seqres_by_pdb_alltissues[pdb].has_key(seqres_chain) == False:
+                if not seqres_chain in seqres_by_pdb_alltissues[pdb]:
                     seqres_by_pdb_alltissues[pdb][seqres_chain] = 0
                 seqres_by_pdb_alltissues[pdb][seqres_chain] += 1
             f.close()
 
             # sort PDBs
-            pdbs = seqres_by_pdb.keys()
-            pdbs.sort()
+            pdbs = sorted(seqres_by_pdb)
 
             # write to file
             out_filename = 'collected.' + filename[6:]
             out_filepath = os.path.join(opts['data_dir'], out_filename)
             with open(out_filepath, 'w') as wf:
                 for pdb in pdbs:
-                    seqress = seqres_by_pdb[pdb].keys()
-                    seqress.sort()
-                    line_info = [pdb, str(len(no_sample[pdb].keys())),
+                    seqress = sorted(seqres_by_pdb[pdb])
+                    line_info = [pdb, str(len(list(no_sample[pdb]))),
                                  ', '.join([seqres + '_' + str(seqres_by_pdb[pdb][seqres])
                                             for seqres in seqress])]
                     wf.write('\t'.join(line_info) + '\n')

--- a/scripts/mupit/filter_hypermutated.py
+++ b/scripts/mupit/filter_hypermutated.py
@@ -157,9 +157,9 @@ def main(opts):
             mupit_filename = 'non_filtered_mupit.' + filename
             mupit_filepath = os.path.join(opts['data_dir'], mupit_filename)
             if tissue != 'PANCAN12':
-                print 'Working on {0}'.format(tissue)
+                print('Working on {0}'.format(tissue))
             else:
-                print '{0} is already filtered. Will skip filter.'.format(tissue)
+                print('{0} is already filtered. Will skip filter.'.format(tissue))
 
             # filter out lines with hypermutated samples
             output = []

--- a/scripts/mupit/format_mutations_table.py
+++ b/scripts/mupit/format_mutations_table.py
@@ -22,7 +22,7 @@ def main(opts):
 
             # make sure it exists
             if os.path.exists(file_path) == False:
-                print '  does not exist.'
+                print('  does not exist.')
                 continue
 
             # read in data

--- a/scripts/mupit/load_mutations_table.py
+++ b/scripts/mupit/load_mutations_table.py
@@ -1,5 +1,6 @@
 """This script loads mutation counts into the MuPIT mutations table."""
 import MySQLdb
+import MySQLdb.cursors
 import os
 import sys
 import argparse
@@ -64,7 +65,8 @@ def main(opts):
     db = MySQLdb.connect(host=opts['host'],
                          user=opts['mysql_user'],
                          passwd=opts['mysql_passwd'],
-                         db=opts['db'])
+                         db=opts['db'],
+                         cursorclass=MySQLdb.cursors.DictCursor, local_infile=1)
     cursor = db.cursor()
 
     # update mutations table

--- a/scripts/mupit/map_maf_to_structure.py
+++ b/scripts/mupit/map_maf_to_structure.py
@@ -85,11 +85,13 @@ def main(opts):
                     # shorten the sample ID if it is a TCGA barcode
                     if sample.startswith('TCGA'):
                         sample = sample[:12]
+                    else:
+                        sample = sample
 
                     # check if mutation is a duplicate
                     variant_id = sample + '_' + chrom + '_' + start + '_' + end + '_' + ref_base + '_' + alt_base
-                    if distinct_variants.has_key(variant_id):
-                        #print(filename + ':' + variant_id + ': duplicate')
+                    if variant_id in distinct_variants:
+                        print(filename + ':' + variant_id + ': duplicate')
                         continue
                     else:
                         distinct_variants[variant_id] = True

--- a/scripts/mupit/merge_mutations_table_data.py
+++ b/scripts/mupit/merge_mutations_table_data.py
@@ -18,7 +18,7 @@ def make_mutations_table_data (mupit_dir):
 
 
 if len(sys.argv) != 2:
-    print 'Usage: python make_table_data.py output_dir'
+    print('Usage: python make_table_data.py output_dir')
     sys.exit()
 
 outdir = sys.argv[1]

--- a/src/mutations.py
+++ b/src/mutations.py
@@ -1,5 +1,5 @@
-import utils
-import pdb_structure as pstruct
+import src.utils
+import src.pdb_structure as pstruct
 
 # get logger
 import logging

--- a/src/pdb_structure.py
+++ b/src/pdb_structure.py
@@ -1,6 +1,6 @@
 import numpy as np
-from density import *
-import utils
+from src.density import *
+import src.utils
 import Bio.PDB
 import string
 import os
@@ -521,7 +521,7 @@ def get_buried_residues(structure, cutoff, tmp_dir, dssp_path):
         try:
             orig_model_chain = list(id_map[full_id[1:3]])
         except:
-            print full_id, id_map
+            print(full_id, id_map)
             raise
         # fix missing letter for homology models
         if orig_model_chain[1] == ' ':

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -98,7 +98,7 @@ def generate_null_dist(struct_id, model_info, chain_info,
     # simulation
     sim_density = []
     prng = np.random.RandomState(seed=seed)
-    res_keys = cog.keys()
+    res_keys = list(cog.keys())
     model_diff = False
     chain_diff = False
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -201,8 +201,10 @@ def read_structure(pdb_path, structure_id, quiet=True):
             for chain in model:
                 if chain.id == " ":
                     chain.id = "A"
-                    del model.child_dict[' ']
                     model.child_dict['A'] = chain
+                    assert ' ' not in model.child_dict
+                    #del model.child_dict[' ']
+                    #model.child_dict['A'] = chain
 
         return structure
     except KeyboardInterrupt:


### PR DESCRIPTION
Total changes added:

**Updated code to be compatible with Python3:**

- Changed `dict.has_key(key)` to `key in dict` as `.has_key()` was removed in Python3
- Changed `dict.keys()` to `list(dict)` as `.keys()` does not return a list in Python3 and instead returns a set object 
- Changed `dict_keys.sort()` to `sorted(dict)`
- Added parentheses to print statements
- Changed `open(file, 'wb')` to `open(file, 'w')` to fix errors in writing files
- configparser module is not imported as ConfigParser in python3, and `configparser.SafeConfigParser()` is deprecated. Changed to `import configparser` and `configparser.ConfigParser()`

**Updated code for specific HotMAPS applications:**

- In `scripts/multiple_testing_correction.py`: Original code gets tumor type value by splitting file name using `filename.split("_")[-1]'`. Changed this to split by `filename.split("mupit_mutations_")[-1]` to handle analyses/tumour types that include underscores
- In `scripts/mupit/load_mutations_table.py`: For running MySQL from within a Python script on GSC: added import statement `import MySQLdb.cursors` and added options to statement that connects to the MySQLdb: `... cursorclass=MySQLdb.cursors.DictCursor, local_infile=1)`
- Added more detailed import statements when running HotMAPS scripts outside of script directory: e.g changed `import utils` to `import src.utils` 
- In `src/utils.py`: removed `del model.child_dict[' ']`, `model.child_dict[' ']` and replaced with `assert ' ' not in model.child_dict` as previous line, `chain.id = "A"` and `model.child_dict['A'] = chain` already replaces value of any child_dicts named ' ' with an 'A', thus model.child_dict[' '] does not exist anymore and throws a KeyError.
- In `scripts/add_path_info.py`: Added ability to find PDB paths that are .gzipped
- In `scripts/add_path_info.py`: Added ability to look for non-biological assembly files that have been downloaded within divided subdirectories by getting the divided subdirectory name from the PDB structure name using `subdir = struct_id[1:3]`
- In `scripts/chain_description.py`: fixed issue reading in PDB structures by changing `with gzip.open(non_bio_pdb_path, 'rb') as gzhandle` to `with gzip.open(non_bio_pdb_path, 'rt') as gzhandle`
