### PR TITLE
Add support for longer subset names

### DIFF
--- a/multiple_testing_correction.py
+++ b/multiple_testing_correction.py
@@ -262,7 +262,6 @@ def main(opts):
         # print the tumor type we're on
         #ttype = m_file.split('_')[-1]
         ttype = m_file.split('mupit_mutations_')[-1]
-        ttype = ttype[:10]
         # skip cancer type if no mutations/hotspots.
         # usually only happens if they use only a couple structures
         # and not the full PDB

--- a/scripts/mupit/load_mutations_table.py
+++ b/scripts/mupit/load_mutations_table.py
@@ -35,7 +35,7 @@ def parse_arguments():
 def make_mutations_table(cursor, db, file_name):
     """Completely drop mutations table and re-load from file."""
     cursor.execute('drop table if exists mutations')
-    cursor.execute('create table mutations (source varchar(10), tissue varchar(10), structure_id varchar(20), residues varchar(10), occurrence int) engine=innodb')
+    cursor.execute('create table mutations (source varchar(100), tissue varchar(10), structure_id varchar(20), residues varchar(10), occurrence int) engine=innodb')
     cursor.execute('load data local infile \'' + file_name + '\' into table mutations')
     db.commit()
 


### PR DESCRIPTION
- Removed char limits from multiple_test_correct to support subset names longer than 10 characters
- Increased character limit of table "mutations" from MySQL database "mupit_modbase" so that, if user does not use --update-table flag in "load_mutations" step, table is not recreated with a shorter character limit for tissue status AKA subset name. Character limit is now 100 which should accommodate any subset names