### PR TITLE
Handle inconsistent column numbers that arise during divide_pdb_info.…

### DIFF
--- a/scripts/get_hotspot_residues.py
+++ b/scripts/get_hotspot_residues.py
@@ -38,6 +38,9 @@ def main(opts):
 
         # iterate over every structure/tumor type pair
         for line in myreader:
+
+            assert(len(line) == len(header)), f"ERROR: A line in {opts['input']} may be truncated and contains incorrect number of columns. This may be due to an error during hotspot.py execution. Please rerun the hotspot.py script again to resolve the error.\nThe line that triggered this error is:\n{line}"
+
             # skip if no p-values
             if not line[pval_ix]:
                 continue

--- a/src/utils.py
+++ b/src/utils.py
@@ -100,7 +100,7 @@ def read_pdb_info(pdb_info_path):
         assert(all(len(line) == len(header) for line in myreader)), f"Not all lines in {pdb_info_path} contain the same number of columns as the header ({len(header)} columns). If running hotspot in parallel, try to rerun divide_pdb_info.py to resolve issue."
 
         handle.seek(0)
-        handle = next(myreader)
+        header = next(myreader)
 
         for pdbid, lines in it.groupby(myreader, lambda x: x[0]):
             # convert from iterator to list

--- a/src/utils.py
+++ b/src/utils.py
@@ -94,8 +94,14 @@ def read_pdb_info(pdb_info_path):
     """
     pdb_info_dict = {}
     with open(pdb_info_path) as handle:
-        handle.readline()
         myreader = csv.reader(handle, delimiter='\t')
+        header = next(myreader)
+
+        assert(all(len(line) == len(header) for line in myreader)), f"Not all lines in {pdb_info_path} contain the same number of columns as the header ({len(header)} columns). If running hotspot in parallel, try to rerun divide_pdb_info.py to resolve issue."
+
+        handle.seek(0)
+        handle = next(myreader)
+
         for pdbid, lines in it.groupby(myreader, lambda x: x[0]):
             # convert from iterator to list
             # for convenience
@@ -131,8 +137,15 @@ def read_mutations(mut_path):
     """
     mut_dict = {}
     with open(mut_path) as handle:
-        handle.readline()
+
         myreader = csv.reader(handle, delimiter='\t')
+        header = next(myreader)
+
+        assert(all(len(line) == len(header) for line in myreader)), f"Not all lines in {mut_path} contain the same number of columns as the header ({len(header)} columns). If running hotspot in parallel, try to rerun divide_pdb_info.py to resolve issue."
+
+        handle.seek(0)
+        header = next(myreader)
+
         for pdbid, lines in it.groupby(myreader, lambda x: x[0]):
 
             # convert lines from an iterator to a list


### PR DESCRIPTION
…py/hotspot.py execution

Errors can occur during execution of `hotspot.py` due to strange parsing/splitting mistakes that arise when splitting up PDB structures and mutations files (when running HotMAPS in parallel) via `scripts/divide_pdb_info.py`. The mistakes would result in truncated or cut-off lines with improper columns, leading to errors when files are being parsed by `hotspot.py` in the following step.

`hotspot.py` execution could also occasionally incorporate truncated/cut-off lines into it's output files, often with no clear explanation of what input file line the values were obtained from. These truncated lines would go on to be incorporated to the `hotspot.py`'s output file,`output_merged.txt`, and lead to parsing errors during `multiple_testing_correction.py`.

In these scenarios it is best to rerun `divide_pdb_info.py` / `hotspot.py` execution depending on cause. Assert statements were added to ensure number of columns in each line are equal to columns in file header, and include detailed error messages if not the case.